### PR TITLE
Add ability to set additional s3-related parameters

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,6 +103,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   value: {{ .Values.s3.secure | quote }}
 {{- end -}}
 
+{{- if .Values.s3.chunksize }}
+- name: REGISTRY_STORAGE_S3_CHUNKSIZE
+  value: {{ .Values.s3.chunksize | quote }}
+{{- end -}}
+
+{{- if .Values.s3.multipartcopychunksize }}
+- name: REGISTRY_STORAGE_S3_MULTIPARTCOPYCHUNKSIZE
+  value: {{ .Values.s3.multipartcopychunksize | quote }}
+{{- end -}}
+
+{{- if .Values.s3.multipartcopymaxconcurrency }}
+- name: REGISTRY_STORAGE_S3_MULTIPARTCOPYMAXCONCURRENCY
+  value: {{ .Values.s3.multipartcopymaxconcurrency | quote }}
+{{- end -}}
+
+{{- if .Values.s3.multipartcopythresholdsize }}
+- name: REGISTRY_STORAGE_S3_MULTIPARTCOPYTHRESHOLDSIZE
+  value: {{ .Values.s3.multipartcopythresholdsize | quote }}
+{{- end -}}
+
+{{- if .Values.redirect }}
+- name: REGISTRY_STORAGE_REDIRECT
+  value: {{ .Values.redirect | quote }}
+{{- end -}}
+
 {{- else if eq .Values.storage "swift" }}
 - name: REGISTRY_STORAGE_SWIFT_AUTHURL
   value: {{ required ".Values.swift.authurl is required" .Values.swift.authurl }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -123,9 +123,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   value: {{ .Values.s3.multipartcopythresholdsize | quote }}
 {{- end -}}
 
-{{- if .Values.redirect }}
-- name: REGISTRY_STORAGE_REDIRECT
-  value: {{ .Values.redirect | quote }}
+{{- if .Values.redirect.disable }}
+- name: REGISTRY_STORAGE_REDIRECT_DISABLE
+  value: {{ .Values.redirect.disable | quote }}
 {{- end -}}
 
 {{- else if eq .Values.storage "swift" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -123,11 +123,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   value: {{ .Values.s3.multipartcopythresholdsize | quote }}
 {{- end -}}
 
-{{- if .Values.redirect.disable }}
-- name: REGISTRY_STORAGE_REDIRECT_DISABLE
-  value: {{ .Values.redirect.disable | quote }}
-{{- end -}}
-
 {{- else if eq .Values.storage "swift" }}
 - name: REGISTRY_STORAGE_SWIFT_AUTHURL
   value: {{ required ".Values.swift.authurl is required" .Values.swift.authurl }}

--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,13 @@ secrets:
 #  rootdirectory: /object/prefix
 #  encrypt: false
 #  secure: true
+#  chunksize: 5242880
+#  multipartcopychunksize: 33554432
+#  multipartcopymaxconcurrency: 100
+#  multipartcopythresholdsize: 33554432
+
+# redirect:
+#  disable: false 
 
 # Options for swift storage type:
 # swift:

--- a/values.yaml
+++ b/values.yaml
@@ -107,9 +107,6 @@ secrets:
 #  multipartcopymaxconcurrency: 100
 #  multipartcopythresholdsize: 33554432
 
-# redirect:
-#  disable: false 
-
 # Options for swift storage type:
 # swift:
 #  authurl: http://swift.example.com/


### PR DESCRIPTION
Specifically, the multipartcopythreasholdsize is required to be set higher than the default value for the registry to work in some object storage instances. 